### PR TITLE
Remove hardcoded DB credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Tests are in `tests/`; run with:
 pytest --asyncio-mode=auto --cov=src --cov-report=html
 Configuration
 config/api_config.yaml: Main scraping + DB parameters
-Environment variables override YAML settings:
-SCRAPER_ENV, POSTGRES_HOST, LOG_LEVEL, etc.
+Environment variables override YAML settings. Database credentials are pulled
+from `POSTGRES_*` variables or files so no passwords live in the repo.
 CI/CD
 Minimal example in .github/workflows/ci.yml sets up mypy checks, lint, bandit, tests, code coverage.
 Monitoring

--- a/config/api_config.yaml
+++ b/config/api_config.yaml
@@ -54,8 +54,8 @@ scraper:
 # ==============================================
   database:
     enabled: true
-    # Use environment variables or secrets in production to secure the connection string.
-    connection_string: "postgresql://username:password@localhost:5432/jobsdb"
+    # Connection string will be built from POSTGRES_* environment variables
+    connection_string: ""
     schema: "public"
     batch_size: 1000         # Maximum number of jobs per bulk insert.
     save_raw_data: true      # Option to also save raw data locally.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,10 @@ services:
     environment:
       - SCRAPER_ENV=production
       - TZ=Asia/Tehran
-      - POSTGRES_HOST=db
-      - POSTGRES_PORT=5432
-      - POSTGRES_DB=jobsdb
-      - POSTGRES_USER=jobuser
+      - POSTGRES_HOST=${POSTGRES_HOST:-db}
+      - POSTGRES_PORT=${POSTGRES_PORT:-5432}
+      - POSTGRES_DB=${POSTGRES_DB:-jobsdb}
+      - POSTGRES_USER=${POSTGRES_USER:-jobuser}
       - POSTGRES_PASSWORD_FILE=/run/secrets/db_password
       - ENABLE_CRON=true
       - RUN_ON_START=true
@@ -58,8 +58,8 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./init-db:/docker-entrypoint-initdb.d
     environment:
-      - POSTGRES_DB=jobsdb
-      - POSTGRES_USER=jobuser
+      - POSTGRES_DB=${POSTGRES_DB:-jobsdb}
+      - POSTGRES_USER=${POSTGRES_USER:-jobuser}
       - POSTGRES_PASSWORD_FILE=/run/secrets/db_password
       - POSTGRES_INITDB_ARGS="--data-checksums"
     secrets:

--- a/main.py
+++ b/main.py
@@ -136,7 +136,7 @@ def load_config() -> Dict[str, Any]:
             "log_level": "INFO",
         },
         "database": {
-            "connection_string": "postgresql://postgres:postgres@localhost:5432/jobsdb",
+            "connection_string": "",
             "schema": "public",
             "pool_size": 10,
         },
@@ -163,22 +163,21 @@ def load_config() -> Dict[str, Any]:
             logging.warning(f"Error loading config file: {str(e)}")
 
     # Merge environment variables for DB / app / scraper
-    if os.getenv("POSTGRES_HOST"):
-        db_user = os.getenv("POSTGRES_USER", "postgres")
-        db_password = os.getenv("POSTGRES_PASSWORD", "")
-        db_host = os.getenv("POSTGRES_HOST", "localhost")
-        db_port = os.getenv("POSTGRES_PORT", "5432")
-        db_name = os.getenv("POSTGRES_DB", "jobsdb")
+    db_user = os.getenv("POSTGRES_USER", "postgres")
+    db_password = os.getenv("POSTGRES_PASSWORD", "")
+    db_host = os.getenv("POSTGRES_HOST", "localhost")
+    db_port = os.getenv("POSTGRES_PORT", "5432")
+    db_name = os.getenv("POSTGRES_DB", "jobsdb")
 
-        # If password is in a file, read it
-        pw_file = os.getenv("POSTGRES_PASSWORD_FILE")
-        if pw_file and os.path.exists(pw_file):
-            with open(pw_file, "r", encoding="utf-8") as pf:
-                db_password = pf.read().strip()
+    # If password is provided via file, prefer that
+    pw_file = os.getenv("POSTGRES_PASSWORD_FILE")
+    if not db_password and pw_file and os.path.exists(pw_file):
+        with open(pw_file, "r", encoding="utf-8") as pf:
+            db_password = pf.read().strip()
 
-        config["database"]["connection_string"] = (
-            f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
-        )
+    config["database"]["connection_string"] = (
+        f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+    )
 
     # Overwrite app config if present
     if os.getenv("SCRAPER_ENV"):


### PR DESCRIPTION
## Summary
- drop credentials from config/api_config.yaml
- build DB connection string from `POSTGRES_*` env vars in `load_config`
- use env variable expansion for DB settings in docker-compose
- clarify README about environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419c000e0083308fcdb203f6ff5eed