### PR TITLE
Fix Superset command interpolation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,8 +125,8 @@ services:
       - superset_home:/app/superset_home
     command: >
       /bin/bash -c '
-        DB_PASS=$(cat /run/secrets/db_password) &&
-        export SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://jobuser:$DB_PASS@db:5432/jobsdb" &&
+        DB_PASS=$$(cat /run/secrets/db_password) &&
+        export SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://jobuser:$$DB_PASS@db:5432/jobsdb" &&
         superset fab create-admin --username admin --password admin --firstname Admin --lastname User --email admin@example.com &&
         superset db upgrade &&
         superset init &&


### PR DESCRIPTION
## Summary
- escape `$` in `superset` service command so Docker Compose doesn't try to interpolate environment variables

## Testing
- `make build` *(fails: Connection refused as Docker daemon cannot be reached)*

------
https://chatgpt.com/codex/tasks/task_e_6841c9e0033c8330b1fa088015e33145