### PR TITLE
Add data transformation utilities

### DIFF
--- a/src/config_models.py
+++ b/src/config_models.py
@@ -3,20 +3,30 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 
-class APIConfig(BaseModel):
+class ConfigBase(BaseModel):
+    """Base model that supports dict-style access."""
+
+    def __getitem__(self, item: str):
+        return getattr(self, item)
+
+    def get(self, item: str, default: Any = None) -> Any:
+        return getattr(self, item, default)
+
+
+class APIConfig(ConfigBase):
     """Configuration options for the API section."""
 
-    base_url: str = Field(..., description="Base URL for the API endpoint")
-    headers: Dict[str, str] = Field(..., description="HTTP headers to include")
+    base_url: str = Field("", description="Base URL for the API endpoint")
+    headers: Dict[str, str] = Field(default_factory=dict, description="HTTP headers to include")
 
 
-class RequestConfig(BaseModel):
+class RequestConfig(ConfigBase):
     """Default request payload settings."""
 
     default_payload: Dict[str, Any] = Field(default_factory=dict)
 
 
-class DatabaseConfig(BaseModel):
+class DatabaseConfig(ConfigBase):
     """Database related configuration."""
 
     enabled: bool = False
@@ -29,67 +39,67 @@ class DatabaseConfig(BaseModel):
     retry_delay: int = 5
 
 
-class RateLimitConfig(BaseModel):
+class RateLimitConfig(ConfigBase):
     requests_per_minute: int = 60
     burst: int = 5
 
 
-class RetryDelayConfig(BaseModel):
+class RetryDelayConfig(ConfigBase):
     min: int = 2
     max: int = 10
 
 
-class StateTrackingConfig(BaseModel):
+class StateTrackingConfig(ConfigBase):
     enabled: bool = True
     save_interval: int = 300
     backup_count: int = 3
 
 
-class TimestampSettings(BaseModel):
+class TimestampSettings(ConfigBase):
     format: str = "%Y-%m-%dT%H:%M:%S.%fZ"
     timezone: str = "UTC"
 
 
-class DeduplicationConfig(BaseModel):
+class DeduplicationConfig(ConfigBase):
     enabled: bool = True
     method: str = "id_based"
     cache_size: int = 10000
 
 
-class MonitoringConfig(BaseModel):
+class MonitoringConfig(ConfigBase):
     enabled: bool = False
     metrics: List[str] = Field(default_factory=list)
     alert_thresholds: Dict[str, int] = Field(default_factory=dict)
 
 
-class ValidationConfig(BaseModel):
+class ValidationConfig(ConfigBase):
     enabled: bool = False
     required_fields: List[str] = Field(default_factory=list)
 
 
-class OutputConfig(BaseModel):
+class OutputConfig(ConfigBase):
     format: str = "json"
     compression: bool = True
     batch_prefix: str = "batch_"
     timestamp_format: str = "%Y%m%d_%H%M%S"
 
 
-class CleanupConfig(BaseModel):
+class CleanupConfig(ConfigBase):
     enabled: bool = True
     max_age_days: int = 7
     keep_last_n_batches: int = 50
 
 
-class DebugConfig(BaseModel):
+class DebugConfig(ConfigBase):
     enabled: bool = False
     verbose_logging: bool = False
     save_raw_responses: bool = False
 
 
-class ScraperConfig(BaseModel):
+class ScraperConfig(ConfigBase):
     """Main scraper configuration options."""
 
-    database: DatabaseConfig
+    database: DatabaseConfig = DatabaseConfig()
     batch_size: int = 100
     jobs_per_batch: int = 1000
     max_pages: int = 1000
@@ -116,7 +126,7 @@ class ScraperConfig(BaseModel):
     error_sleep_time: int = 2
 
 
-class AppConfig(BaseModel):
-    api: APIConfig
-    request: RequestConfig
-    scraper: ScraperConfig
+class AppConfig(ConfigBase):
+    api: APIConfig = APIConfig()
+    request: RequestConfig = RequestConfig()
+    scraper: ScraperConfig = ScraperConfig()

--- a/src/data_transform.py
+++ b/src/data_transform.py
@@ -1,0 +1,74 @@
+"""Utilities for transforming raw job data into structured tables."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Tuple
+
+import pandas as pd
+
+
+def load_raw_csv(path: str | Path) -> pd.DataFrame:
+    """Load the CSV file with a ``raw_data`` column containing JSON strings."""
+
+    df = pd.read_csv(path)
+    df["raw_json"] = df["raw_data"].apply(json.loads)
+    return df
+
+
+def extract_tables(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Convert the raw JSON column into normalized job, company and location tables."""
+
+    job_records = []
+    company_records = []
+    location_records = []
+
+    for row in df["raw_json"]:
+        job_id = row.get("id")
+        company = row.get("companyDetailsSummary") or {}
+        company_id = company.get("id")
+
+        job_records.append(
+            {
+                "job_id": job_id,
+                "title": row.get("title"),
+                "salary": row.get("salary"),
+                "company_id": company_id,
+                "gender": row.get("gender"),
+                "payment_method": row.get("paymentMethod"),
+                "activation_time": (row.get("activationTime") or {}).get("date"),
+            }
+        )
+
+        if company:
+            company_records.append(
+                {
+                    "company_id": company_id,
+                    "name_fa": (company.get("name") or {}).get("titleFa"),
+                    "name_en": (company.get("name") or {}).get("titleEn"),
+                    "about": (company.get("about") or {}).get("titleFa"),
+                    "url": company.get("url"),
+                }
+            )
+
+        for loc in row.get("locations", []):
+            location_records.append(
+                {
+                    "job_id": job_id,
+                    "province_id": (loc.get("province") or {}).get("id"),
+                    "province_title": (loc.get("province") or {}).get("titleFa"),
+                    "city_id": (loc.get("city") or {}).get("id"),
+                    "city_title": (loc.get("city") or {}).get("titleFa"),
+                }
+            )
+
+    jobs_df = pd.DataFrame(job_records)
+    companies_df = pd.DataFrame(company_records).drop_duplicates("company_id")
+    locations_df = pd.DataFrame(location_records)
+
+    return jobs_df, companies_df, locations_df
+
+
+__all__ = ["load_raw_csv", "extract_tables"]
+

--- a/tests/test_data_transform.py
+++ b/tests/test_data_transform.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from src import data_transform
+
+
+def test_extract_tables(tmp_path):
+    csv_content = """created_at,id,raw_data,COUNT(*)
+2025-06-05,1,"{""id"": 1, ""title"": ""Test"", ""companyDetailsSummary"": {""id"": 10, ""name"": {""titleFa"": ""Co""}}, ""locations"": []}",1
+"""
+    path = tmp_path / "jobs.csv"
+    path.write_text(csv_content)
+
+    df = data_transform.load_raw_csv(path)
+    jobs, companies, locations = data_transform.extract_tables(df)
+
+    assert len(jobs) == 1
+    assert jobs.loc[0, "job_id"] == 1
+    assert len(companies) == 1
+    assert companies.loc[0, "company_id"] == 10
+    assert locations.empty


### PR DESCRIPTION
## Summary
- implement ConfigBase to provide dict-style access for Pydantic models
- provide default values in config models so minimal config loads
- add `data_transform` module to normalize scraped job data into tables
- test data transformation helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841dcb5544c8330bd72c77f246d169a