### PR TITLE
Add Superset dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Run tests from the repository root with:
 
 ```bash
 pytest --asyncio-mode=auto --cov=src --cov-report=html
+```
 
 Configuration
 config/api_config.yaml: Main scraping + DB parameters
@@ -55,6 +56,18 @@ Environment variables override YAML settings. Database credentials are pulled
 from `POSTGRES_*` variables or files so no passwords live in the repo.
 CI/CD
 Minimal example in .github/workflows/ci.yml sets up mypy checks, lint, bandit, tests, code coverage.
+
+## Data Visualization with Superset
+This project integrates [Apache Superset](https://superset.apache.org/) for exploring the scraped
+PostgreSQL data. Start the service with:
+
+```bash
+docker-compose up -d superset
+```
+
+Then visit [http://localhost:8088](http://localhost:8088) and log in using the default credentials
+`admin` / `admin`. Configure a new Postgres database connection pointing to the `db` service to
+build charts and dashboards.
 Monitoring
 health.py listens on /health and /metrics.
 Integration with Prometheus or other monitoring solutions is possible by adding Prometheus exporters.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,11 +110,29 @@ services:
       retries: 3
       start_period: 30s
 
+  superset:
+    image: apache/superset:latest
+    container_name: superset_app
+    environment:
+      - ADMIN_PASSWORD=admin
+      - SUPERSET_SECRET_KEY=change_me
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - superset_home:/app/superset_home
+    ports:
+      - "8088:8088"
+    networks:
+      - scraper-network
+
 volumes:
   postgres_data:
     name: job_postgres_data
   pgadmin_data:
     name: job_pgadmin_data
+  superset_home:
+    name: job_superset_home
 
 networks:
   scraper-network:


### PR DESCRIPTION
## Summary
- integrate Apache Superset via docker-compose for free data visualization
- document Superset usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841e50a4cb483309e6d51de44995ce7