### PR TITLE
Auto init Superset

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,11 @@ PostgreSQL data. Start the service with:
 docker-compose up -d superset
 ```
 
-Then visit [http://localhost:8088](http://localhost:8088) and log in using the default credentials
-`admin` / `admin`. Configure a new Postgres database connection pointing to the `db` service to
+The container automatically initializes its database and creates the default
+`admin` account on first start. Once running, visit
+[http://localhost:8088](http://localhost:8088) and log in using the default
+credentials `admin` / `admin`.
+Configure a new Postgres database connection pointing to the `db` service to
 build charts and dashboards.
 Monitoring
 health.py listens on /health and /metrics.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,8 +121,10 @@ services:
         condition: service_healthy
     volumes:
       - superset_home:/app/superset_home
+      - ./superset-init.sh:/app/superset-init.sh
     ports:
       - "8088:8088"
+    command: ["/bin/bash", "/app/superset-init.sh"]
     networks:
       - scraper-network
 

--- a/superset-init.sh
+++ b/superset-init.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Initialize the database
+superset db upgrade
+
+# Create an admin user if it doesn't exist
+superset fab create-admin \
+    --username admin \
+    --firstname admin \
+    --lastname admin \
+    --email admin@example.com \
+    --password ${ADMIN_PASSWORD:-admin} || true
+
+# Set up roles and permissions
+superset init
+
+# Start the Superset server
+/usr/bin/run-server.sh


### PR DESCRIPTION
## Summary
- add a small startup script to initialise Superset and create the admin user
- update docker compose to run this script
- document that the admin account is created automatically

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f00e20008330a5486b848c1d992c