### PR TITLE
Automate Superset DB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,13 @@ PostgreSQL data. Start the service with:
 docker-compose up -d superset
 ```
 
-Then visit [http://localhost:8088](http://localhost:8088) and log in using the default credentials
-`admin` / `admin`. Configure a new Postgres database connection pointing to the `db` service to
-build charts and dashboards.
+The container automatically initializes its database, creates the default
+`admin` account, and registers the included PostgreSQL instance. Once running,
+visit [http://localhost:8088](http://localhost:8088) and log in using the
+default credentials `admin` / `admin`. Superset is pre-configured to connect to
+the `jobsdb` database so you can start building charts immediately. The container
+installs the PostgreSQL driver at startup using
+`PIP_ADDITIONAL_REQUIREMENTS=psycopg2-binary`.
 Monitoring
 health.py listens on /health and /metrics.
 Integration with Prometheus or other monitoring solutions is possible by adding Prometheus exporters.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,15 +116,26 @@ services:
     environment:
       - ADMIN_PASSWORD=admin
       - SUPERSET_SECRET_KEY=change_me
+      - APP_DB_HOST=${POSTGRES_HOST:-db}
+      - APP_DB_PORT=${POSTGRES_PORT:-5432}
+      - APP_DB_NAME=${POSTGRES_DB:-jobsdb}
+      - APP_DB_USER=${POSTGRES_USER:-jobuser}
+      - APP_DB_PASSWORD_FILE=/run/secrets/db_password
+      - PIP_ADDITIONAL_REQUIREMENTS=psycopg2-binary
     depends_on:
       db:
         condition: service_healthy
     volumes:
       - superset_home:/app/superset_home
+      - ./superset-init.sh:/app/superset-init.sh
+      - ./scripts:/app/scripts:ro
     ports:
       - "8088:8088"
+    command: ["/bin/bash", "/app/superset-init.sh"]
     networks:
       - scraper-network
+    secrets:
+      - db_password
 
 volumes:
   postgres_data:

--- a/scripts/create_superset_connection.py
+++ b/scripts/create_superset_connection.py
@@ -1,0 +1,23 @@
+import os
+from superset.app import create_app
+from superset.extensions import db
+from superset.models.core import Database
+
+app = create_app()
+
+with app.app_context():
+    host = os.environ.get("APP_DB_HOST", "db")
+    port = os.environ.get("APP_DB_PORT", "5432")
+    name = os.environ.get("APP_DB_NAME", "jobsdb")
+    user = os.environ.get("APP_DB_USER", "jobuser")
+    password = os.environ.get("APP_DB_PASSWORD", "")
+
+    uri = f"postgresql+psycopg2://{user}:{password}@{host}:{port}/{name}"
+
+    if not Database.query.filter_by(database_name=name).first():
+        db_obj = Database(database_name=name, sqlalchemy_uri=uri)
+        db.session.add(db_obj)
+        db.session.commit()
+        print(f"Database '{name}' created in Superset")
+    else:
+        print(f"Database '{name}' already configured")

--- a/superset-init.sh
+++ b/superset-init.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Initialize the database
+superset db upgrade
+
+# Create an admin user if it doesn't exist
+superset fab create-admin \
+    --username admin \
+    --firstname admin \
+    --lastname admin \
+    --email admin@example.com \
+    --password ${ADMIN_PASSWORD:-admin} || true
+
+# Set up roles and permissions
+superset init
+
+# Configure default database connection in Superset
+if [ -f "${APP_DB_PASSWORD_FILE:-/run/secrets/db_password}" ]; then
+  export APP_DB_PASSWORD="$(cat ${APP_DB_PASSWORD_FILE:-/run/secrets/db_password})"
+fi
+python /app/scripts/create_superset_connection.py || true
+
+# Start the Superset server
+/usr/bin/run-server.sh


### PR DESCRIPTION
## Summary
- automate adding the jobs database to Superset at startup
- expose DB connection parameters to Superset container
- document that Superset now pre-loads the PostgreSQL connection
- install `psycopg2` in the Superset image so the connection works

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841f00e20008330a5486b848c1d992c