### PR TITLE
Fix README directory tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,23 @@ A Python 3.11+ asynchronous application that scrapes job postings from remote AP
 
 ## Directory Structure
 
-job_scraper/ ├── Dockerfile ├── docker-compose.yml ├── main.py ├── src/ │ ├── log_setup.py <-- Central logging config │ ├── scraper.py │ ├── scheduler.py │ ├── db_manager.py │ ├── config_manager.py │ ├── health.py ├── tests/ │ ├── test_db_manager.py │ └── test_scraper.py └── ...
-
-perl
-Copy
-Edit
+```
+job_scraper/
+├── Dockerfile
+├── docker-compose.yml
+├── main.py
+├── src/
+│   ├── log_setup.py        # Central logging config
+│   ├── scraper.py
+│   ├── scheduler.py
+│   ├── db_manager.py
+│   ├── config_manager.py
+│   └── health.py
+├── tests/
+│   ├── test_db_manager.py
+│   └── test_scraper.py
+└── ...
+```
 
 ## Major Components
 1. **`main.py`**  


### PR DESCRIPTION
## Summary
- clean stray text around directory listing
- format directory tree as code block

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68420d381a2083308011b9ee703e3662