### PR TITLE
docs: clarify test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ The scraper container runs automatically, uses a cron job to schedule repeated s
 The project uses `pytest` with the `pytest-asyncio` plugin. Both packages are
 included in `requirements.txt`.
 
+Before running the tests make sure all dependencies are installed:
+
+```bash
+pip install -r requirements.txt
+```
+
+If Codex doesn't have internet access you can prepare a `setup.sh` script to
+install the packages during container startup.
+
 Run tests from the repository root with:
 
 ```bash


### PR DESCRIPTION
## Summary
- document requirement to install dependencies before running tests
- note that Codex environments without internet access can use a `setup.sh` script

## Testing
- `pip install -r requirements.txt`
- `pytest --asyncio-mode=auto --cov=src --cov-report=html`


------
https://chatgpt.com/codex/tasks/task_e_68420d659d088330ad76c82b2c2cb115