### PR TITLE
Add note about installing dependencies for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Run tests from the repository root with:
 pytest --asyncio-mode=auto --cov=src --cov-report=html
 ```
 
+Before running the tests, make sure the Python dependencies are installed:
+
+```bash
+pip install -r requirements.txt
+```
+
+If Codex does not have internet access when your environment is created,
+consider placing the install command in a `setup.sh` script so the required
+packages can be preinstalled during container setup.
+
 Configuration
 config/api_config.yaml: Main scraping + DB parameters
 Environment variables override YAML settings. Database credentials are pulled


### PR DESCRIPTION
## Summary
- clarify in README that dependencies must be installed before running tests
- mention `setup.sh` as an offline install option for Codex

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420e6767d48330911a32147df90589