### PR TITLE
Install optional packages at Superset startup

### DIFF
--- a/superset-init.sh
+++ b/superset-init.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# Install additional Python packages if specified (e.g., database drivers)
+if [ -n "${PIP_ADDITIONAL_REQUIREMENTS:-}" ]; then
+  echo "Installing additional Python packages: ${PIP_ADDITIONAL_REQUIREMENTS}"
+  pip install --no-cache-dir ${PIP_ADDITIONAL_REQUIREMENTS}
+fi
+
 # Initialize the database
 superset db upgrade
 


### PR DESCRIPTION
## Summary
- ensure Superset installs optional packages such as psycopg2 at container startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421a2378248330897a092ae1d74d1c