### PR TITLE
Keep scraper container healthy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN echo "/app/job_data/logs/*.log {\n\
     && chmod 0644 /etc/logrotate.d/scraper
 
 # Set up cron jobs for scheduled scraping every 6 hours + daily logrotate
-RUN echo "0 */6 * * * cd /app && /usr/local/bin/python /app/main.py >> /app/job_data/logs/cron.log 2>&1" \
+RUN echo "0 */6 * * * cd /app && ENABLE_HEALTH_CHECK=false /usr/local/bin/python /app/main.py >> /app/job_data/logs/cron.log 2>&1" \
     > /etc/cron.d/scraper-cron \
     && echo "0 0 * * * /usr/sbin/logrotate /etc/logrotate.d/scraper --state /app/job_data/logs/logrotate.status" \
     >> /etc/cron.d/scraper-cron \

--- a/scripts/health_server.py
+++ b/scripts/health_server.py
@@ -1,0 +1,27 @@
+import asyncio
+from main import load_config
+from src.db_manager import DatabaseManager
+from src.health import HealthCheck
+
+
+async def main() -> None:
+    config = load_config()
+    db_conn = config["database"]["connection_string"]
+    db_manager = DatabaseManager(connection_string=db_conn)
+    await db_manager.initialize()
+    health = HealthCheck(db_manager)
+    host = config["app"].get("health_host", "0.0.0.0")
+    port = config["app"].get("health_port", 8080)
+    runner, _ = await health.start(host=host, port=port)
+    try:
+        while True:
+            await asyncio.sleep(3600)
+    except asyncio.CancelledError:
+        pass
+    finally:
+        await runner.cleanup()
+        await db_manager.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- run a dedicated health server in the container
- disable embedded health checks for scheduled scraper runs
- update cron job to respect this new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest --asyncio-mode=auto --cov=src --cov-report=html`

------
https://chatgpt.com/codex/tasks/task_e_68433a141c208330a4fc25772d6f7523