### PR TITLE
Fix pages processed count in scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,38 @@ job_scraper/
    - Exposes `aiohttp`-based endpoints for health and metrics checks.
 6. **`log_setup.py`** (newly added)  
    - Centralized logging logic to be imported by other modules.
-7. **`scheduler.py`**: `JobScraperScheduler`  
+7. **`scheduler.py`**: `JobScraperScheduler`
    - Repeated scheduled runs of the scraper in a loop.
+
+## Scraper Data Flow
+
+The following diagram outlines how a single run of the scraper processes data:
+
+```
+JobScraper.run()
+    |
+    v
+  initialize()
+    |
+    v
+  scrape()
+    |
+    v
+  fetch_jobs()  ->  process_jobs()  ->  _process_jobs()
+                                    /                \
+                           insert_jobs()          save_batch()
+                                    \                /
+                                    _save_batch_with_state()
+                                              |
+                                              v
+                                 _log_final_statistics()
+```
+
+`fetch_jobs()` retrieves raw pages from the API. `process_jobs()` validates and
+filters records. `_process_jobs()` writes the cleaned jobs to the database via
+`insert_jobs()` (or `save_batch()` when storing locally). After each batch,
+`_save_batch_with_state()` persists progress and finally
+`_log_final_statistics()` records summary metrics.
 
 ## Setup & Installation
 

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -78,6 +78,7 @@ class JobScraper:
         self.current_batch: int = 0
         self.total_jobs_scraped: int = 0
         self.failed_requests: List[int] = []
+        self.pages_processed: int = 0
 
         # Concurrency limit for HTTP requests
         max_concurrent = self.scraper_config.max_concurrent_requests
@@ -389,9 +390,12 @@ class JobScraper:
             if current_batch_jobs:
                 processed_count = await self._process_jobs(current_batch_jobs)
                 self.total_jobs_scraped += processed_count
-                await self._save_batch_with_state(current_batch_jobs, batch_num, page)
-
-            await self._log_final_statistics(pages_processed=page - 1)
+                # Use the last successfully processed page for state tracking
+                await self._save_batch_with_state(
+                    current_batch_jobs, batch_num, page - 1
+                )
+            self.pages_processed = page - 1
+            await self._log_final_statistics(pages_processed=self.pages_processed)
 
     async def _save_batch_with_state(
         self, jobs: List[Dict[str, Any]], batch_num: int, current_page: int
@@ -487,7 +491,7 @@ class JobScraper:
             self.logger.info("Job scraper completed successfully.")
             return {
                 "total_jobs": self.total_jobs_scraped,
-                "pages_processed": self.current_batch,
+                "pages_processed": self.pages_processed,
                 "status": "completed",
             }
         except Exception as e:


### PR DESCRIPTION
## Summary
- ensure pages processed count is tracked separately from batch count
- expose correct pages_processed value in scraper results
- document scraper data flow
- fix final state page tracking

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68452a3e5ddc8330b31ff2ca4393e8a6