### PR TITLE
Fix Superset driver install

### DIFF
--- a/Dockerfile.superset
+++ b/Dockerfile.superset
@@ -1,0 +1,9 @@
+FROM apache/superset:latest
+
+# Install the Postgres driver inside Superset's virtualenv
+USER root
+RUN pip install --no-cache-dir psycopg2-binary \
+    && su -s /bin/sh superset -c "pip install --no-cache-dir psycopg2-binary"
+
+USER superset
+CMD ["/bin/bash", "/app/superset-init.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,9 @@ services:
       start_period: 30s
 
   superset:
-    image: apache/superset:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.superset
     container_name: superset_app
     environment:
       - ADMIN_PASSWORD=admin
@@ -123,7 +125,6 @@ services:
       - APP_DB_PASSWORD_FILE=/run/secrets/db_password
       # Optional full SQLAlchemy URI. Overrides the individual settings above if provided
       - APP_DB_URI=${APP_DB_URI:-}
-      - PIP_ADDITIONAL_REQUIREMENTS=psycopg2-binary
 
     depends_on:
       db:

--- a/superset-init.sh
+++ b/superset-init.sh
@@ -2,9 +2,14 @@
 set -e
 
 # Install additional Python packages if specified (e.g., database drivers)
+PIP_BIN="/app/.venv/bin/pip"
+if [ ! -x "$PIP_BIN" ]; then
+  PIP_BIN="$(command -v pip)"
+fi
+
 if [ -n "${PIP_ADDITIONAL_REQUIREMENTS:-}" ]; then
   echo "Installing additional Python packages: ${PIP_ADDITIONAL_REQUIREMENTS}"
-  pip install --no-cache-dir ${PIP_ADDITIONAL_REQUIREMENTS}
+  "$PIP_BIN" install --no-cache-dir ${PIP_ADDITIONAL_REQUIREMENTS}
 fi
 
 # Initialize the database


### PR DESCRIPTION
## Summary
- build custom Superset image that preinstalls psycopg2-binary
- remove runtime pip install from docker-compose

## Testing
- `ruff check docker-compose.yml Dockerfile.superset superset-init.sh`
- `pytest --asyncio-mode=auto --cov=src --cov-report=html`


------
https://chatgpt.com/codex/tasks/task_e_685ddd3a65448330b8b95c022623ee42