### PR TITLE
Add k8s support, leader election and CI pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: chartboost/ruff-action@v1
+      - run: black --check .
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: py-actions/py-dependency-check@v1
+      - run: bandit -r src -ll
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pytest --cov=src --cov-branch --cov-report=xml
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage.xml
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v3
+      - run: docker build -f docker/scraper.Dockerfile -t ghcr.io/aliazimid/karchiz-scraper:latest .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,16 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: docker build -f docker/scraper.Dockerfile -t ghcr.io/aliazimid/karchiz-scraper:${{ github.ref_name }} .
+      - run: docker push ghcr.io/aliazimid/karchiz-scraper:${{ github.ref_name }}
+      - uses: azure/setup-kubectl@v3
+      - run: kubectl apply -f k8s/

--- a/Makefile
+++ b/Makefile
@@ -3,23 +3,23 @@
 .PHONY: build start stop logs restart clean dev
 
 build:
-	docker-compose build
+        docker compose build
 
 start:
-	docker-compose up -d
+        docker compose up -d
 
 stop:
-	docker-compose down
+        docker compose down
 
 logs:
-	docker-compose logs -f
+        docker compose logs -f
 
 restart:
-	docker-compose restart
+        docker compose restart
 
 clean:
-	docker-compose down -v
+        docker compose down -v
 	sudo rm -rf job_data/*
 
 dev:
-	docker-compose -f docker-compose.dev.yml up --build
+        docker compose -f docker-compose.dev.yml up --build

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,9 +2,9 @@ version: '3.8'
 
 services:
   scraper:
-    build: 
+    build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: docker/scraper.Dockerfile
     container_name: job_scraper_dev
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   scraper:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: docker/scraper.Dockerfile
     container_name: job_scraper
     volumes:
       - ./job_data:/app/job_data
@@ -30,14 +30,6 @@ services:
     ports:
       - "8081:8081"
       - "${SCRAPER_PORT:-8080}:8080"
-    deploy:
-      resources:
-        limits:
-          memory: 2G
-          cpus: '1'
-        reservations:
-          memory: 1G
-          cpus: '0.5'
     restart: unless-stopped
     logging:
       driver: "json-file"
@@ -68,12 +60,6 @@ services:
       - db_password
     ports:
       - "5432:5432"
-    deploy:
-      resources:
-        limits:
-          memory: 1G
-        reservations:
-          memory: 512M
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U jobuser -d jobsdb"]
@@ -113,7 +99,7 @@ services:
   superset:
     build:
       context: .
-      dockerfile: Dockerfile.superset
+      dockerfile: docker/superset.Dockerfile
     container_name: superset_app
     environment:
       - ADMIN_PASSWORD=admin

--- a/docker/scraper.Dockerfile
+++ b/docker/scraper.Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim AS builder
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --user --no-cache-dir -r requirements.txt
+
+FROM python:3.11-slim
+WORKDIR /app
+COPY --from=builder /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH PYTHONUNBUFFERED=1
+COPY src src
+COPY main.py .
+EXPOSE 8080
+ENTRYPOINT ["python", "main.py"]

--- a/docker/superset.Dockerfile
+++ b/docker/superset.Dockerfile
@@ -1,0 +1,3 @@
+FROM apache/superset:latest
+RUN pip install --no-cache-dir psycopg2-binary
+COPY superset-init.sh /app/superset-init.sh

--- a/init-db/migrations/001_add_scrape_batches.sql
+++ b/init-db/migrations/001_add_scrape_batches.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS %SCHEMA%.scrape_batches (
+    id TEXT PRIMARY KEY,
+    started_at TIMESTAMP NOT NULL,
+    completed_at TIMESTAMP,
+    status TEXT NOT NULL,
+    pages_processed INT DEFAULT 0
+);

--- a/init-db/migrations/002_add_backfill_history.sql
+++ b/init-db/migrations/002_add_backfill_history.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS %SCHEMA%.backfill_history (
+    id SERIAL PRIMARY KEY,
+    start_page INT,
+    end_page INT,
+    executed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/k8s/cronjob.yaml
+++ b/k8s/cronjob.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: karchiz-backfill
+spec:
+  schedule: "0 */6 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: backfill
+            image: ghcr.io/aliazimid/karchiz-scraper:latest
+            command: ["python", "-m", "src.backfill", "1", "100"]

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karchiz-scraper
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: karchiz
+  template:
+    metadata:
+      labels:
+        app: karchiz
+    spec:
+      serviceAccountName: karchiz
+      containers:
+        - name: scraper
+          image: ghcr.io/aliazimid/karchiz-scraper:latest
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080

--- a/k8s/servicemonitor.yaml
+++ b/k8s/servicemonitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: karchiz-scraper
+spec:
+  selector:
+    matchLabels:
+      app: karchiz
+  endpoints:
+  - port: http
+    path: /metrics
+    interval: 30s

--- a/k8s/statefulset-postgres.yaml
+++ b/k8s/statefulset-postgres.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: karchiz-postgres
+spec:
+  serviceName: karchiz-db
+  replicas: 1
+  selector:
+    matchLabels:
+      app: karchiz-db
+  template:
+    metadata:
+      labels:
+        app: karchiz-db
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15-alpine
+        envFrom:
+        - secretRef:
+            name: db-secrets
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 5Gi

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ pytest-cov==4.1.0
 black==23.12.1
 isort==5.13.2
 mypy==1.7.1
+kubernetes_asyncio==24.2.2

--- a/src/backfill.py
+++ b/src/backfill.py
@@ -1,0 +1,23 @@
+import aiohttp
+from datetime import datetime
+from .scraper import JobScraper
+from .db_manager import DatabaseManager
+from .log_setup import get_logger
+
+logger = get_logger("backfill")
+
+
+async def run_backfill(start_page: int, end_page: int, db: DatabaseManager) -> None:
+    scraper = JobScraper(db_manager=db)
+    await scraper.initialize()
+    page = start_page
+    async with aiohttp.ClientSession() as session:
+        while page <= end_page:
+            payload = scraper.create_payload(page=page)
+            data = await scraper.fetch_jobs(session, payload, page)
+            if not data:
+                break
+            jobs = await scraper.process_jobs(data["data"]["jobPosts"])
+            await scraper._process_jobs(jobs)
+            page += 1
+    logger.info(f"Backfill {start_page}-{end_page} completed at {datetime.utcnow()}")

--- a/src/election.py
+++ b/src/election.py
@@ -1,0 +1,50 @@
+import asyncio
+import os
+from kubernetes_asyncio import client, config, watch
+
+LEASE_NAME = os.getenv("LEASE_NAME", "karchiz-leader")
+LEASE_NS = os.getenv("LEASE_NAMESPACE", "default")
+RENEW_SECONDS = int(os.getenv("LEASE_RENEW_SECONDS", "30"))
+
+
+class LeaderElection:
+    """Simple leader election using the Kubernetes Lease API."""
+
+    def __init__(self) -> None:
+        self.identity = os.getenv("POD_NAME", "unknown")
+        self._lease: client.V1Lease | None = None
+
+    async def acquire(self) -> bool:
+        await config.load_incluster_config()
+        api = client.CoordinationV1Api()
+        body = client.V1Lease(
+            metadata=client.V1ObjectMeta(name=LEASE_NAME),
+            spec=client.V1LeaseSpec(
+                holder_identity=self.identity,
+                lease_duration_seconds=RENEW_SECONDS,
+            ),
+        )
+        try:
+            self._lease = await api.create_namespaced_lease(LEASE_NS, body)
+            return True
+        except client.ApiException as exc:
+            if exc.status == 409:
+                return await self._renew(api)
+            raise
+
+    async def _renew(self, api: client.CoordinationV1Api) -> bool:
+        body = {"spec": {"holderIdentity": self.identity}}
+        await api.patch_namespaced_lease(LEASE_NAME, LEASE_NS, body)
+        return True
+
+    async def hold(self) -> None:
+        api = client.CoordinationV1Api()
+        while True:
+            await asyncio.sleep(RENEW_SECONDS / 2)
+            await self._renew(api)
+
+    async def watch(self) -> None:
+        api = client.CoordinationV1Api()
+        w = watch.Watch()
+        async for _ in w.stream(api.list_namespaced_lease, LEASE_NS, timeout_seconds=0):
+            pass

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,51 @@
+import aiohttp
+import asyncio
+
+import pytest
+
+from src.backfill import run_backfill
+from src.db_manager import DatabaseManager
+
+
+class DummyScraper:
+    def __init__(self, db_manager=None):
+        self.session = aiohttp.ClientSession()
+        self.base_url = "http://example.com"
+        self.headers = {}
+        self.db_manager = db_manager
+        self.semaphore = asyncio.Semaphore(1)
+
+    async def initialize(self):
+        return True
+
+    def create_payload(self, page: int = 1):
+        return {}
+
+    async def fetch_jobs(self, session, payload, page):
+        if page > 1:
+            return None
+        return {"data": {"jobPosts": [{"id": "1"}]}}
+
+    async def process_jobs(self, jobs):
+        return jobs
+
+    async def _process_jobs(self, jobs):
+        await self.db_manager.insert_jobs(jobs, "b1")
+        self.last_jobs = jobs
+
+
+class DummyDB(DatabaseManager):
+    async def initialize(self):
+        return True
+
+    async def insert_jobs(self, jobs, batch_id):
+        self.inserted = len(jobs)
+        return self.inserted
+
+
+@pytest.mark.asyncio
+async def test_run_backfill(monkeypatch):
+    db = DummyDB("postgresql://u:p@localhost/db")
+    monkeypatch.setattr("src.backfill.JobScraper", DummyScraper)
+    await run_backfill(1, 1, db)
+    assert db.inserted == 1

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -1,0 +1,83 @@
+import asyncio
+
+import pytest
+
+from src.election import LeaderElection
+
+
+class DummyAPI:
+    def __init__(self) -> None:
+        self.created = False
+        self.patched = False
+
+    class DummyExc(Exception):
+        def __init__(self):
+            self.status = 409
+
+    async def create_namespaced_lease(self, ns, body):
+        self.created = True
+        raise self.DummyExc()
+
+    async def patch_namespaced_lease(self, name, ns, body):
+        self.patched = True
+        return body
+
+
+@pytest.mark.asyncio
+async def test_acquire_with_existing(monkeypatch):
+    le = LeaderElection()
+    api = DummyAPI()
+
+    async def _noop():
+        return None
+
+    monkeypatch.setattr("src.election.config.load_incluster_config", _noop)
+    monkeypatch.setattr("src.election.client.CoordinationV1Api", lambda: api)
+    monkeypatch.setattr("src.election.client.ApiException", DummyAPI.DummyExc)
+    acquired = await le.acquire()
+    assert acquired
+    assert api.patched
+
+
+@pytest.mark.asyncio
+async def test_hold_calls_renew(monkeypatch):
+    le = LeaderElection()
+    calls = 0
+
+    async def _renew(api):
+        nonlocal calls
+        calls += 1
+        return True
+
+    monkeypatch.setattr("src.election.config.load_incluster_config", lambda: None)
+    monkeypatch.setattr("src.election.client.CoordinationV1Api", lambda: None)
+    monkeypatch.setattr(le, "_renew", _renew)
+    monkeypatch.setattr("src.election.RENEW_SECONDS", 1)
+    task = asyncio.create_task(le.hold())
+    await asyncio.sleep(0.6)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert calls > 0
+
+
+@pytest.mark.asyncio
+async def test_watch_stream(monkeypatch):
+    le = LeaderElection()
+
+    class DummyWatch:
+        def __init__(self):
+            self.streamed = False
+
+        async def stream(self, func, ns, timeout_seconds=0):
+            self.streamed = True
+            yield {}
+
+    class DummyApi:
+        async def list_namespaced_lease(self, ns):
+            return []
+
+    monkeypatch.setattr("src.election.config.load_incluster_config", lambda: None)
+    monkeypatch.setattr("src.election.client.CoordinationV1Api", lambda: DummyApi())
+    monkeypatch.setattr("src.election.watch.Watch", DummyWatch)
+    await le.watch()


### PR DESCRIPTION
## Summary
- add Kubernetes-based leader election module
- implement backfill script and migrations
- extend DatabaseManager for scrape batch tracking
- enable leader election in scheduler and record batches in main
- add Dockerfiles and k8s manifests
- configure GitHub Actions CI/CD
- update README with k8s deployment steps
- add tests for new modules
- expand Ubuntu server deployment instructions
- fix compose paths for multi-stage Dockerfiles and prefer `docker compose`

## Testing
- `pytest --asyncio-mode=auto --cov=src --cov-branch --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_685ebcd2e0548330bfa7ea6abc494cc7