### PR TITLE
Fix Superset psycopg2 install and scraper syntax

### DIFF
--- a/docker/superset.Dockerfile
+++ b/docker/superset.Dockerfile
@@ -1,3 +1,8 @@
 FROM apache/superset:latest
-RUN pip install --no-cache-dir psycopg2-binary
+
+# Install the PostgreSQL driver inside Superset's virtual environment
+USER root
+RUN /app/.venv/bin/pip install --no-cache-dir psycopg2-binary
+USER superset
+
 COPY superset-init.sh /app/superset-init.sh

--- a/src/db_manager.py
+++ b/src/db_manager.py
@@ -487,7 +487,8 @@ class DatabaseManager:
         tags = job.get("tags", []) if isinstance(job.get("tags"), list) else []
 
         def tag_present(text: str) -> int:
-            return 1 if text in tags : 0
+            """Return 1 if the tag text is present in the job's tag list."""
+            return 1 if text in tags else 0
 
         primary_city = None
         if isinstance(job.get("locations"), list) and job["locations"]:
@@ -867,13 +868,15 @@ class DatabaseManager:
             self.engine.dispose()
         logger.info("Database connections closed")
 
+
 def normalize_company_id(record):
     """
     Ensure company_id is always a string in the given record.
     """
-    if 'company_id' in record and record['company_id'] is not None:
-        record['company_id'] = str(record['company_id'])
+    if "company_id" in record and record["company_id"] is not None:
+        record["company_id"] = str(record["company_id"])
     return record
+
 
 # Use this function wherever records are processed before DB operations, e.g.:
 # records = [normalize_company_id(r) for r in records]


### PR DESCRIPTION
## Summary
- install PostgreSQL driver in Superset image using the built-in venv
- correct ternary syntax in `DatabaseManager`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860d8f72c8c8330b91900730628615c