### PR TITLE
Fix Superset build

### DIFF
--- a/docker/superset.Dockerfile
+++ b/docker/superset.Dockerfile
@@ -2,7 +2,8 @@ FROM apache/superset:latest
 
 # Install the PostgreSQL driver inside Superset's virtual environment
 USER root
-RUN /app/.venv/bin/pip install --no-cache-dir psycopg2-binary
+RUN pip install --no-cache-dir psycopg2-binary \
+    && su -s /bin/sh superset -c "pip install --no-cache-dir psycopg2-binary"
 USER superset
 
 COPY superset-init.sh /app/superset-init.sh


### PR DESCRIPTION
## Summary
- repair Superset Dockerfile so psycopg2 installs correctly

## Testing
- `pip install -r requirements.txt`
- `pytest --asyncio-mode=auto --cov=src --cov-report=html`


------
https://chatgpt.com/codex/tasks/task_e_6860dae3fa54833094760f87627a71f0